### PR TITLE
Update Geoserver REST API URL

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -10,8 +10,7 @@ It provides primitive Ruby model abstraction.
 == Documentation
 The GeoServer REST Configuration API Reference can be found here:
 
-http://docs.geoserver.org/stable/en/user/restconfig/rest-config-api.html
-
+http://docs.geoserver.org/stable/en/user/rest/index.html
  
 == Installation 
 


### PR DESCRIPTION
Really minor change for the URL which has recently been moved in the generated documentation
